### PR TITLE
fix: correct spelling typos across FR and EN content

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -166,7 +166,7 @@ function ToggleThemeColorsButton({className = "", shouldDisplayText = false}) {
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2"
                     d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"/>
             </svg>
-            {shouldDisplayText && <span>{isEnglish ? <>Light&nbsp;Theme</> : <>Thème&nbsp;foncé</>}</span>}
+            {shouldDisplayText && <span>{isEnglish ? <>Light&nbsp;Theme</> : <>Thème&nbsp;clair</>}</span>}
           </div>
         )
       }

--- a/pages/a-propos.js
+++ b/pages/a-propos.js
@@ -15,11 +15,11 @@ export default function About() {
           <h2>À propos d'Alex Desroches</h2>
           <p>
             Je suis un <strong>passionné de programmation</strong>, cinéma, jeux vidéos, musique, composition musicale,
-            théologie et philosophie. Bref, à peu près tout ce qui éveil mon côté créatif et nourri mon imagination.
+            théologie et philosophie. Bref, à peu près tout ce qui éveille mon côté créatif et nourrit mon imagination.
           </p>
           <p>
             Je suis dans la trentaine, habitant au Canada dans la province du Québec, avec ma chère épouse Cathy
-            et Samuel, notre nouveau né&nbsp;!
+            et Samuel, notre nouveau-né&nbsp;!
           </p>
           <p>
             Depuis mon enfance, <strong>j'aime ce qui est technologique, créatif et qui amène à la
@@ -27,14 +27,14 @@ export default function About() {
             Pour citer un exemple plutôt drôle... étant très jeune, j'ai reçu mon premier piano électronique
             pour Noël et j'ai joué jusqu'à ce que les piles soient épuisées&nbsp;! Cette anecdote démontre encore bien
             ma personnalité d'aujourd'hui. Quand je découvre quelque chose que j'aime, comme la musique ou la
-            programmation, je suis investi à fond sur çà.
+            programmation, je suis investi à fond sur ça.
           </p>
           <p>
             <strong>
               J'ai une personnalité de travailleur&nbsp;: persévérant, passionné et orienté sur l'excellence.
             </strong>{" "}
             Je n'aime pas l'échec et je fais mon mieux à chaque défi pour réussir à bien faire. Quand j'échoue, je le
-            prend difficilement, mais çà me propulse vers d'autres niveaux de persévérance. Ce que j'aime encore moins
+            prends difficilement, mais ça me propulse vers d'autres niveaux de persévérance. Ce que j'aime encore moins
             que l'échec, est l'abandon. Pour moi, abandonner est le véritable échec. Alors,{" "}
             <strong>je m'efforce constamment à progresser</strong> plutôt qu'à me résigner à la défaite.
           </p>

--- a/pages/en/about.js
+++ b/pages/en/about.js
@@ -22,7 +22,7 @@ const About = () => {
           </p>
           <p>
             I am {calculateAge(new Date(1989, 4, 29))} years old, living in Canada in the province
-            of Quebec, with my beloved wife Cathy and our new born son Samuel!
+            of Quebec, with my beloved wife Cathy and our newborn son Samuel!
           </p>
           <p>
             Since my childhood, <strong>I love what is technological, creative and demands reflection</strong>.{" "}
@@ -35,7 +35,7 @@ const About = () => {
             <strong>
               I'm a persevering, passionate and excellence-oriented worker.
             </strong>{" "}
-            I don't like failing and do my best to succeed. When I do fail, I take it hardly, but this is the drive that
+            I don't like failing and do my best to succeed. When I do fail, I take it hard, but this is the drive that
             keeps me wanting more. What I hate the most is giving up. To me, real failure is giving up when you are so
             close to success. This is why{" "}<strong>I constantly strive to progress</strong> rather than resigning
             myself to

--- a/pages/en/programming.js
+++ b/pages/en/programming.js
@@ -182,7 +182,7 @@ const Programming = () => {
           <li>Websites</li>
           <li>Web Apps</li>
           <li>Online Commerce</li>
-          <li>Desktop Softwares</li>
+          <li>Desktop Software</li>
           <li>Web Scraping</li>
           <li>Automation Scripts</li>
           <li>...and more</li>
@@ -256,7 +256,7 @@ const Programming = () => {
           technologies="React.js, JavaScript, HTML, CSS, Node.js, Next.js, Web Hosting Canada, GitHub, Microsoft Outlook,
          Calendly, PHP."
 
-          features="Created the website form scratch with React.js, web hosting and email management, SEO,
+          features="Created the website from scratch with React.js, web hosting and email management, SEO,
            PHP contact form and online booking with Calendly."
 
           timespan="December 2020"

--- a/pages/index.js
+++ b/pages/index.js
@@ -23,7 +23,7 @@ export default function Index() {
           <h3>Mon expertise est le Développement Web Front-End.</h3>
           <p>
             Mes forces en programmation, sont basées principalement sur les langages du Web.
-            C'est-à-dire, HTML, CSS et <strong>JavaScript</strong>; Dont les sites Internet et applications Web
+            C'est-à-dire, HTML, CSS et <strong>JavaScript</strong>; dont les sites Internet et applications Web
             dépendent.
           </p>
           <p>
@@ -38,7 +38,7 @@ export default function Index() {
 
           <h3>Faisons équipe&nbsp;!</h3>
           <p>
-            Confiez-moi un nouveau project ou joignons nos forces en collaborant avec votre équipe.
+            Confiez-moi un nouveau projet ou joignons nos forces en collaborant avec votre équipe.
           </p>
           <div className="handwritten-signature-container display-flex">
             <Link href="/contact" className="text-link">Contactez-moi&nbsp;&rarr;</Link>

--- a/pages/programmation.js
+++ b/pages/programmation.js
@@ -233,7 +233,7 @@ export default function Programmation() {
          Web Hosting Canada, GitHub."
 
           features="Logiciel pour ordinateurs Windows et Mac. Incluant la certification de signature du code avec SSL.com,
-         une documentation complète pour les utilisateurs, la distribution par internet, les mises à jours automatiques,
+         une documentation complète pour les utilisateurs, la distribution par internet, les mises à jour automatiques,
          le soutien technique et un système de logs privé pour assurer la qualité. Au moment de la rédaction, les avis
          d'utilisateurs sur Capterra.ca ont une moyenne de 4.9 étoiles sur 5."
 
@@ -256,7 +256,7 @@ export default function Programmation() {
 
           features="Conception du site avec React, gestion de l'hébergement et des adresses courriels de l'entreprise
         avec Web Hosting Canada pour remplacer Squarespace, optimisations SEO, formulaire de contact PHP et
-        prise de rendez-vous en-ligne avec Calendly."
+        prise de rendez-vous en ligne avec Calendly."
 
           timespan="Créé à contrat pendant le mois de décembre 2020, total environ 30 heures."
 
@@ -277,7 +277,7 @@ export default function Programmation() {
           features="Programmation Full-Stack. C'est-à-dire, le Front-End avec React.js et le Back-End avec Firebase
         pour l'authentification et la base de donnée. Le serveur de license est géré avec WooCommerce License Manager
         et des appels API PHP de l'application vers WooCommerce. L'interface se met à jour en temps réel grâce
-        à React et Firebase real-time similaire à Google Sheets par exemple. La base de donnée est du No-SQL."
+        à React et Firebase real-time similaire à Google Sheets par exemple. La base de données est du No-SQL."
 
           timespan="Créée à contrat en 2021, en investissant quelques heures par mois."
 


### PR DESCRIPTION
French fixes:
- 'Dont' → 'dont' (lowercase after semicolon)
- 'project' → 'projet'
- 'éveil/nourri' → 'éveille/nourrit'
- 'nouveau né' → 'nouveau-né'
- 'çà' → 'ça' (x2)
- 'prend' → 'prends'
- 'en-ligne' → 'en ligne'
- 'donnée' → 'données' (No-SQL database)
- 'mises à jours' → 'mises à jour'

English fixes:
- 'new born' → 'newborn'
- 'take it hardly' → 'take it hard'
- 'form scratch' → 'from scratch'
- 'Softwares' → 'Software'

UI fix:
- Light theme FR label: 'Thème foncé' → 'Thème clair'