### PR TITLE
feat: enhance routing and language toggle; improve image srcSet handl…

### DIFF
--- a/components/ActiveLink.js
+++ b/components/ActiveLink.js
@@ -1,12 +1,16 @@
 // Active Link wrapper for Next.js 15+ Pages Router
 import {useRouter} from 'next/router';
 import Link from 'next/link';
+import {normalizePath} from '../lib/getInternalPageLink';
 
 const ActiveLink = ({children, activeClassName = "active-next-link", className = "", ...props}) => {
   const {asPath} = useRouter();
+  const currentPath = normalizePath(asPath);
+  const hrefPath = normalizePath(props.href);
+  const alternatePath = props.as ? normalizePath(props.as) : null;
 
-  const isActive = asPath === props.href || asPath === props.as;
-  
+  const isActive = currentPath === hrefPath || currentPath === alternatePath;
+
   const finalClassName = isActive
     ? `${className} ${activeClassName}`.trim()
     : className;

--- a/components/ExternalLink.js
+++ b/components/ExternalLink.js
@@ -1,13 +1,23 @@
+import {useIsEnglish} from "../hooks/useIsEnglish";
+
 export default function ExternalLink({url, className, children}) {
+  const isEnglish = useIsEnglish();
+
+  const opensNewTab = /^https?:\/\//i.test(url);
+  const newTabLabel = isEnglish
+    ? "Click to open this link in a new tab"
+    : "Cliquez pour ouvrir ce lien dans un nouvel onglet";
+
   return (
-    <a href={url}
-       target="_blank"
-       rel="noopener noreferrer"
-       aria-label="Cliquez pour ouvrir ce lien dans une nouvelle fenêtre"
-       title="Cliquez pour ouvrir ce lien dans une nouvelle fenêtre"
-       className={className}
+    <a
+      href={url}
+      target={opensNewTab ? "_blank" : undefined}
+      rel={opensNewTab ? "noopener noreferrer" : undefined}
+      aria-label={newTabLabel}
+      title={newTabLabel}
+      className={className}
     >
       {children}
     </a>
-  )
+  );
 }

--- a/components/Header.js
+++ b/components/Header.js
@@ -3,6 +3,7 @@ import {useTheme} from 'next-themes';
 import {useIsEnglish} from "../hooks/useIsEnglish";
 import InternalLink from "./InternalLink";
 import {useRouter} from "next/router";
+import {getAlternateInternalPath} from "../lib/getInternalPageLink";
 
 
 export default function Header() {
@@ -175,16 +176,16 @@ function ToggleThemeColorsButton({className = "", shouldDisplayText = false}) {
 }
 
 function ToggleLanguageButton({className = "", shouldDisplayText = false}) {
-  const router = useRouter()
-  const isEnglish = useIsEnglish()
+  const router = useRouter();
+  const isEnglish = useIsEnglish();
 
   const toggleLang = () => {
-    router.push(isEnglish ? "/" : "/en/")
-  }
+    router.push(getAlternateInternalPath(router.asPath));
+  };
 
   return (
     <button
-      className={"toggle-button language" + className}
+      className={`toggle-button language${className ? ` ${className}` : ""}`}
       aria-label="Toggle Website Language"
       type="button"
       onClick={toggleLang}

--- a/components/ResponsiveImage.js
+++ b/components/ResponsiveImage.js
@@ -20,7 +20,7 @@ export default function ResponsiveImage(
         type="image/webp"
       />
       <img
-        srcSet={`${path}.jpg ${desktopWidth}w, ${path}-${mobileWidth}w.jpg`}
+        srcSet={`${path}.jpg ${desktopWidth}w, ${path}-${mobileWidth}w.jpg ${mobileWidth}w`}
         src={`${path}.jpg`}
         alt={alt}
         width={renderedWidth}
@@ -28,6 +28,6 @@ export default function ResponsiveImage(
         className={className || ""}
       />
     </picture>
-  )
+  );
 }
 

--- a/hooks/useIsEnglish.js
+++ b/hooks/useIsEnglish.js
@@ -1,11 +1,10 @@
 import {useRouter} from "next/router";
+import {isEnglishPath} from "../lib/getInternalPageLink";
 
 
 function useIsEnglish() {
-  const router = useRouter()
-  const regEx = new RegExp(/\/en\//)
-  const isEnglish = regEx.test(router.asPath)
-  return Boolean(isEnglish)
+  const router = useRouter();
+  return isEnglishPath(router.asPath);
 }
 
-export {useIsEnglish}
+export {useIsEnglish};

--- a/lib/getInternalPageLink.js
+++ b/lib/getInternalPageLink.js
@@ -1,10 +1,79 @@
-const pages = {
-  index: (isEnglish) => isEnglish ? "/en/" : "/",
-  programming: (isEnglish) => isEnglish ? "/en/programming/" : "/programmation/",
-  about: (isEnglish) => isEnglish ? "/en/about/" : "/a-propos/",
-  contact: (isEnglish) => isEnglish ? "/en/contact/" : "/contact/",
-  resume: (isEnglish) => isEnglish ? "/en/resume/" : "/resume/",
+const internalPagePaths = {
+  index: {
+    fr: "/",
+    en: "/en/",
+  },
+  programming: {
+    fr: "/programmation/",
+    en: "/en/programming/",
+  },
+  about: {
+    fr: "/a-propos/",
+    en: "/en/about/",
+  },
+  contact: {
+    fr: "/contact/",
+    en: "/en/contact/",
+  },
+  resume: {
+    fr: "/resume/",
+    en: "/en/resume/",
+  },
+};
+
+function splitPathAndSuffix(path = "/") {
+  const matchedPath = String(path).match(/^([^?#]*)(.*)$/);
+
+  return {
+    pathname: matchedPath?.[1] || "/",
+    suffix: matchedPath?.[2] || "",
+  };
 }
 
+function normalizePath(path = "/") {
+  const {pathname} = splitPathAndSuffix(path);
 
-export default pages
+  if (!pathname || pathname === "/") {
+    return "/";
+  }
+
+  const trimmedPath = pathname.replace(/\/+$/, "");
+  return trimmedPath || "/";
+}
+
+function isEnglishPath(path = "/") {
+  const normalizedPath = normalizePath(path);
+  return normalizedPath === "/en" || normalizedPath.startsWith("/en/");
+}
+
+function getAlternateInternalPath(path = "/") {
+  const {pathname, suffix} = splitPathAndSuffix(path);
+  const normalizedPath = normalizePath(pathname);
+
+  for (const localizedPaths of Object.values(internalPagePaths)) {
+    if (normalizePath(localizedPaths.en) === normalizedPath) {
+      return `${localizedPaths.fr}${suffix}`;
+    }
+
+    if (normalizePath(localizedPaths.fr) === normalizedPath) {
+      return `${localizedPaths.en}${suffix}`;
+    }
+  }
+
+  const fallbackPath = isEnglishPath(normalizedPath)
+    ? internalPagePaths.index.fr
+    : internalPagePaths.index.en;
+
+  return `${fallbackPath}${suffix}`;
+}
+
+const pages = Object.fromEntries(
+  Object.entries(internalPagePaths).map(([pageName, localizedPaths]) => ([
+    pageName,
+    (isEnglish) => (isEnglish ? localizedPaths.en : localizedPaths.fr),
+  ]))
+);
+
+export {getAlternateInternalPath, isEnglishPath, normalizePath};
+
+export default pages;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "postbuild": "next-sitemap --config next-sitemap.config.js",
     "preview": "next start",
-    "lint": "next lint"
+    "lint": "eslint ."
   },
   "author": {
     "name": "Alex Desroches",


### PR DESCRIPTION
…ing (amended)

Amendments by Hermes Agent to codex/review (GPT-5.4):

- ActiveLink: remove SSR fallback to pathname to prevent hydration mismatch.
- ExternalLink: always provide language-aware aria-label + title for all links (including mailto/tel), while only applying target=_blank to https? links.
- useIsEnglish: remove SSR fallback to pathname for consistency.
- Header language toggle: use router.asPath directly without fallback.

Original work (GPT-5.4):
- Centralized routing map with FR/EN pairs and utilities
- Language toggle routes to equivalent page (not always home)
- ActiveLink normalization fixes trailing-slash mismatches
- useIsEnglish regex fix for /en/ home page edge case
- ExternalLink i18n aria-labels and smarter target logic
- ResponsiveImage JPEG srcSet width descriptor fix