### PR TITLE
fix: remove GitLab from skills list

### DIFF
--- a/pages/en/programming.js
+++ b/pages/en/programming.js
@@ -100,7 +100,7 @@ const Programming = () => {
               </li>
               <li>
                 <ExternalLink url="https://en.wikipedia.org/wiki/GitHub">
-                  Git, GitHub, GitLab
+                  Git, GitHub
                 </ExternalLink>
               </li>
               <li>

--- a/pages/programmation.js
+++ b/pages/programmation.js
@@ -101,7 +101,7 @@ export default function Programmation() {
               </li>
               <li>
                 <ExternalLink url="https://en.wikipedia.org/wiki/GitHub">
-                  Git, GitHub, GitLab
+                  Git, GitHub
                 </ExternalLink>
               </li>
               <li>


### PR DESCRIPTION
Updated both language versions to remove GitLab, keeping only Git and GitHub.