### PR TITLE
fix: update French location text in footer

### DIFF
--- a/components/Footer.js
+++ b/components/Footer.js
@@ -30,8 +30,7 @@ export default function Footer() {
                     Services de programmation
                   </InternalLink>
                 </strong> à la demande.
-                Programmeur situé sur la Rive-Sud de
-                Montréal. Tarification à l'heure avec
+                Programmeur situé près de Montréal. Tarification à l'heure avec
                 facture détaillée à l'appui.
               </>
             )


### PR DESCRIPTION
Changed "Programmeur situé sur la Rive-Sud de Montréal" to "Programmeur situé près de Montréal". The English equivalent "Located near Montreal, in Canada" already aligns with this meaning.