### PR TITLE
chore: remove dead resume routes, drop stale date from EN portfolio

### DIFF
--- a/lib/getInternalPageLink.js
+++ b/lib/getInternalPageLink.js
@@ -15,10 +15,6 @@ const internalPagePaths = {
     fr: "/contact/",
     en: "/en/contact/",
   },
-  resume: {
-    fr: "/resume/",
-    en: "/en/resume/",
-  },
 };
 
 function splitPathAndSuffix(path = "/") {

--- a/pages/en/programming.js
+++ b/pages/en/programming.js
@@ -298,7 +298,7 @@ const Programming = () => {
           title="This website"
 
           description="The website you are viewing right now is built with React.js and Next.js. I chose both of these
-          technologies because they are great. Probably my current top choice as of 2022-05-24."
+          technologies because they are great. Probably my current top choice."
 
           imgSrc="/images/programmation/alexdesrochescom/alexdesroches"
 


### PR DESCRIPTION
- lib/getInternalPageLink.js: remove orphaned resume routes (/resume/, /en/resume/) — no corresponding page files exist, dead code only.
- pages/en/programming.js: remove stale hardcoded date 'as of 2022-05-24' from the 'This website' project description; specific ageing dates make a portfolio feel unmaintained.