### PR TITLE
feat: contact form, improved services section, accessibility fixes

### DIFF
--- a/components/ContactForm.js
+++ b/components/ContactForm.js
@@ -1,0 +1,110 @@
+import {useState} from "react";
+import {myContactLinks} from "../lib/myContactLinks";
+import styles from "../styles/contact.module.css";
+
+export default function ContactForm({isEnglish}) {
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [subject, setSubject] = useState("");
+  const [message, setMessage] = useState("");
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    const body = `Name: ${name}%0AEmail: ${email}%0ASubject: ${subject}%0A%0AMessage:%0A${message}`;
+    const mailtoLink = `mailto:${myContactLinks.email}?subject=${encodeURIComponent(subject || "Contact from alexdesroches.com")}&body=${body}`;
+
+    window.open(mailtoLink, "_blank");
+    setSubmitted(true);
+  };
+
+  if (submitted) {
+    return (
+      <div className={styles.formSuccess}>
+        <p>
+          {isEnglish
+            ? "Thanks for reaching out! Your email client should have opened with your message pre-filled. If it didn't open automatically, you can email me directly at:"
+            : "Merci de m'avoir contacté ! Votre client de messagerie devrait s'être ouvert avec votre message pré-rempli. Si ce n'est pas le cas, vous pouvez m'écrire directement à l'adresse :"}
+        </p>
+        <p>
+          <a href={`mailto:${myContactLinks.email}`} className="text-link">
+            {myContactLinks.email}
+          </a>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      className={styles.contactForm}
+      onSubmit={handleSubmit}
+      aria-label={isEnglish ? "Contact form" : "Formulaire de contact"}
+    >
+      <div className={styles.formField}>
+        <label htmlFor="contact-name">
+          {isEnglish ? "Name" : "Nom"}
+        </label>
+        <input
+          id="contact-name"
+          type="text"
+          required
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder={isEnglish ? "Your name" : "Votre nom"}
+        />
+      </div>
+      <div className={styles.formField}>
+        <label htmlFor="contact-email">
+          {isEnglish ? "Email" : "Courriel"}
+        </label>
+        <input
+          id="contact-email"
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder={isEnglish ? "your@email.com" : "votre@email.com"}
+        />
+      </div>
+      <div className={styles.formField}>
+        <label htmlFor="contact-subject">
+          {isEnglish ? "Subject" : "Sujet"}
+        </label>
+        <input
+          id="contact-subject"
+          type="text"
+          required
+          value={subject}
+          onChange={(e) => setSubject(e.target.value)}
+          placeholder={isEnglish ? "Project inquiry" : "Demande de projet"}
+        />
+      </div>
+      <div className={styles.formField}>
+        <label htmlFor="contact-message">
+          {isEnglish ? "Message" : "Message"}
+        </label>
+        <textarea
+          id="contact-message"
+          rows={5}
+          required
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          placeholder={isEnglish ? "Tell me about your project..." : "Parlez-moi de votre projet..."}
+        />
+      </div>
+      <button
+        type="submit"
+        className={styles.submitButton}
+      >
+        {isEnglish ? "Send →" : "Envoyer →"}
+      </button>
+      <p className={styles.formNote}>
+        {isEnglish
+          ? "This will open your email client. Alternatively, you can reach out directly via LinkedIn or email."
+          : "Ceci ouvrira votre client de messagerie. Vous pouvez aussi me contacter directement via LinkedIn ou par courriel."}
+      </p>
+    </form>
+  );
+}

--- a/components/ContactLink.js
+++ b/components/ContactLink.js
@@ -7,6 +7,7 @@ function ContactLink({label, url, svgIcon}) {
       <ExternalLink
         className="text-link"
         url={url}
+        ariaLabel={label}
       >
         {svgIcon}
         {label}&nbsp;&rarr;

--- a/components/ExternalLink.js
+++ b/components/ExternalLink.js
@@ -1,6 +1,10 @@
 import {useIsEnglish} from "../hooks/useIsEnglish";
 
-function getLinkLabel(url, isEnglish, opensNewTab) {
+function getLinkLabel(url, isEnglish, opensNewTab, explicitLabel) {
+  if (explicitLabel) {
+    return explicitLabel;
+  }
+
   if (/^mailto:/i.test(url)) {
     return isEnglish ? "Send an email" : "Envoyer un courriel";
   }
@@ -11,18 +15,18 @@ function getLinkLabel(url, isEnglish, opensNewTab) {
 
   if (opensNewTab) {
     return isEnglish
-      ? "Click to open this link in a new tab"
-      : "Cliquez pour ouvrir ce lien dans un nouvel onglet";
+      ? "Open link in a new tab"
+      : "Ouvrir le lien dans un nouvel onglet";
   }
 
   return undefined;
 }
 
-export default function ExternalLink({url, className, children}) {
+export default function ExternalLink({url, className, ariaLabel, children}) {
   const isEnglish = useIsEnglish();
 
   const opensNewTab = /^https?:\/\//i.test(url);
-  const linkLabel = getLinkLabel(url, isEnglish, opensNewTab);
+  const linkLabel = getLinkLabel(url, isEnglish, opensNewTab, ariaLabel);
 
   return (
     <a

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -71,8 +71,8 @@ export default function Footer() {
       </div>
 
       <div className="footer-links--social">
-        <ExternalLink url={myContactLinks.linkedIn}><LinkedinLogo/></ExternalLink>
-        <ExternalLink url={myContactLinks.github}><GithubLogo/></ExternalLink>
+        <ExternalLink url={myContactLinks.linkedIn} ariaLabel="My LinkedIn profile"><LinkedinLogo/></ExternalLink>
+        <ExternalLink url={myContactLinks.github} ariaLabel="My GitHub profile"><GithubLogo/></ExternalLink>
       </div>
 
       <div>

--- a/components/Header.js
+++ b/components/Header.js
@@ -21,14 +21,14 @@ export default function Header() {
     <div className={`header-container${isMobileMenuOpened ? " is-mobile-menu-open" : ""}`}>
       <header>
         <nav>
-          <h1 className="left-branding">
+          <span className="left-branding">
             <InternalLink
               isActiveLink={true}
               page="index"
             >
               Alex Desroches
             </InternalLink>
-          </h1>
+          </span>
           <ul className="page-links do-not-display-on-mobile">
             <MainNavLinks/>
           </ul>

--- a/components/Project.js
+++ b/components/Project.js
@@ -11,7 +11,7 @@ export default function Project({title, description, imgSrc, features, technolog
       <div className={styles.leftColumn + " max-text-width"}>
         <h3>{title}</h3>
         <p>{description}</p>
-        <ExternalLink url={url}>
+        <ExternalLink url={url} ariaLabel={title}>
           <ResponsiveImage
             path={imgSrc}
             alt={title}

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -1,13 +1,10 @@
 import PageTemplate from "../components/PageTemplate";
 import ResponsiveImage from "../components/ResponsiveImage";
-import ExternalLink from "../components/ExternalLink";
+import styles from "../styles/contact.module.css";
 import {EmailLogo, LinkedinLogo} from "../components/Logos";
-
 import {myContactLinks} from "../lib/myContactLinks";
 import ContactLink from "../components/ContactLink";
-
-import styles from "../styles/contact.module.css";
-
+import ContactForm from "../components/ContactForm";
 
 export default function Contact() {
   return (
@@ -22,53 +19,28 @@ export default function Contact() {
           <h2>Contacter Alex Desroches</h2>
           <p>
             N'hésitez pas à me contacter, ce sera un plaisir de discuter de votre projet.
-            Je suis joignable en tout temps par l'un des moyens ci-dessous&nbsp;:
+            Remplissez le formulaire ci-dessous ou contactez-moi par l'un des moyens suivants :          
           </p>
 
+          <ContactForm isEnglish={false}/>
+
           <ul className={styles.contactLinks}>
-            {/*<ContactLink*/}
-            {/*  label="Messenger"*/}
-            {/*  url={myContactLinks.messenger}*/}
-            {/*  svgIcon={<MessengerLogo/>}*/}
-            {/*/>*/}
             <ContactLink
               label="Courriel"
               url={`mailto:${myContactLinks.email}`}
               svgIcon={<EmailLogo/>}
             />
-            {/* <ContactLink
-              label="Cellulaire"
-              url={`tel:${myContactLinks.cellphone}`}
-              svgIcon={<CellphoneLogo/>}
-            /> */}
             <ContactLink
               label="LinkedIn"
               url={myContactLinks.linkedIn}
               svgIcon={<LinkedinLogo/>}
             />
-            {/*<ContactLink*/}
-            {/*  label="GitHub"*/}
-            {/*  url={myContactLinks.github}*/}
-            {/*  svgIcon={<GithubLogo/>}*/}
-            {/*/>*/}
-            {/*<ContactLink*/}
-            {/*  label="Facebook"*/}
-            {/*  url={myContactLinks.facebook}*/}
-            {/*  svgIcon={<FacebookLogo/>}*/}
-            {/*/>*/}
-            {/*<ContactLink*/}
-            {/*  label="Twitter"*/}
-            {/*  url={myContactLinks.twitter}*/}
-            {/*  svgIcon={<TwitterLogo/>}*/}
-            {/*/>*/}
           </ul>
 
         </section>
 
         <section className="max-text-width">
           <div className="stylish-shadow-image">
-            {/*<span*/}
-            {/*  className={styles.imageTextOverlay + " stylish-shadow-image--overlay-text"}>Art is Communicating</span>*/}
             <ResponsiveImage
               path="/images/celltower/celltower"
               alt="Art is Communicating"

--- a/pages/en/contact.js
+++ b/pages/en/contact.js
@@ -1,12 +1,16 @@
 import PageTemplate from "../../components/PageTemplate";
 import styles from "../../styles/contact.module.css";
 import ContactLink from "../../components/ContactLink";
+import ContactForm from "../../components/ContactForm";
 import {myContactLinks} from "../../lib/myContactLinks";
 import {EmailLogo, LinkedinLogo} from "../../components/Logos";
 import ExternalLink from "../../components/ExternalLink";
 import ResponsiveImage from "../../components/ResponsiveImage";
+import {useIsEnglish} from "../../hooks/useIsEnglish";
 
 const Contact = () => {
+  const isEnglish = useIsEnglish();
+
   return (
     <PageTemplate
       pageTitle={"Contact | " + process.env.NEXT_PUBLIC_WEBSITE_TITLE}
@@ -19,53 +23,28 @@ const Contact = () => {
           <h2>Contact Alex Desroches</h2>
           <p>
             Feel free to contact me, it will be a pleasure to discuss about your project.
-            You can reach me via one of the links below:
+            Fill in the form below or reach me via any of the links:
           </p>
 
+          <ContactForm isEnglish={true}/>
+
           <ul className={styles.contactLinks}>
-            {/*<ContactLink*/}
-            {/*  label="Messenger"*/}
-            {/*  url={myContactLinks.messenger}*/}
-            {/*  svgIcon={<MessengerLogo/>}*/}
-            {/*/>*/}
             <ContactLink
               label="Email"
               url={`mailto:${myContactLinks.email}`}
               svgIcon={<EmailLogo/>}
             />
-            {/* <ContactLink
-              label="Mobile phone"
-              url={`tel:${myContactLinks.cellphone}`}
-              svgIcon={<CellphoneLogo/>}
-            /> */}
             <ContactLink
               label="LinkedIn"
               url={myContactLinks.linkedIn}
               svgIcon={<LinkedinLogo/>}
             />
-            {/*<ContactLink*/}
-            {/*  label="GitHub"*/}
-            {/*  url={myContactLinks.github}*/}
-            {/*  svgIcon={<GithubLogo/>}*/}
-            {/*/>*/}
-            {/*<ContactLink*/}
-            {/*  label="Facebook"*/}
-            {/*  url={myContactLinks.facebook}*/}
-            {/*  svgIcon={<FacebookLogo/>}*/}
-            {/*/>*/}
-            {/*<ContactLink*/}
-            {/*  label="Twitter"*/}
-            {/*  url={myContactLinks.twitter}*/}
-            {/*  svgIcon={<TwitterLogo/>}*/}
-            {/*/>*/}
           </ul>
 
         </section>
 
         <section className="max-text-width">
           <div className="stylish-shadow-image">
-            {/*<span*/}
-            {/*  className={styles.imageTextOverlay + " stylish-shadow-image--overlay-text"}>Art is Communicating</span>*/}
             <ResponsiveImage
               path="/images/celltower/celltower"
               alt="Art is Communicating"

--- a/pages/en/programming.js
+++ b/pages/en/programming.js
@@ -188,15 +188,36 @@ const Programming = () => {
 
       <section className={styles.services}>
         <h3>Offered Services</h3>
-        <ul className="max-text-width">
-          <li>Websites</li>
-          <li>Web Apps</li>
-          <li>Online Commerce</li>
-          <li>Desktop Software</li>
-          <li>Web Scraping</li>
-          <li>Automation Scripts</li>
-          <li>...and more</li>
-        </ul>
+        <div className={styles.servicesGrid}>
+          <div className={styles.serviceCard}>
+            <h4>Websites</h4>
+            <p>Static sites, blogs, and portfolios with a focus on speed, SEO, and accessibility.</p>
+          </div>
+          <div className={styles.serviceCard}>
+            <h4>Web Apps</h4>
+            <p>Dynamic applications with user logins, dashboards, and real-time data.</p>
+          </div>
+          <div className={styles.serviceCard}>
+            <h4>Online Commerce</h4>
+            <p>WooCommerce stores, Stripe integration, and custom checkout flows.</p>
+          </div>
+          <div className={styles.serviceCard}>
+            <h4>Desktop Software</h4>
+            <p>Cross-platform apps for Windows and Mac built with Electron.js.</p>
+          </div>
+          <div className={styles.serviceCard}>
+            <h4>Web Scraping</h4>
+            <p>Data extraction, automation, and API integration for hands-off workflows.</p>
+          </div>
+          <div className={styles.serviceCard}>
+            <h4>Automation Scripts</h4>
+            <p>Windows task automation, file processing, and time-saving tooling.</p>
+          </div>
+          <div className={styles.serviceCard}>
+            <h4>Consulting & Maintenance</h4>
+            <p>Code review, performance optimization, and long-term support.</p>
+          </div>
+        </div>
       </section>
 
       <svg className={styles.waveBottom} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 150">

--- a/pages/programmation.js
+++ b/pages/programmation.js
@@ -189,14 +189,36 @@ export default function Programmation() {
 
       <section className={styles.services}>
         <h3>Services offerts</h3>
-        <ul className="max-text-width">
-          <li>Sites Internet</li>
-          <li>Applications Web</li>
-          <li>Commerces en ligne</li>
-          <li>Logiciels pour ordinateurs</li>
-          <li>Web scraping</li>
-          <li>Scripts d'automatisation</li>
-        </ul>
+        <div className={styles.servicesGrid}>
+          <div className={styles.serviceCard}>
+            <h4>Sites Internet</h4>
+            <p>Sites statiques, blogs et portfolios axés sur la rapidité, le référencement et l'accessibilité.</p>
+          </div>
+          <div className={styles.serviceCard}>
+            <h4>Applications Web</h4>
+            <p>Applications dynamiques avec authentification, tableaux de bord et données en temps réel.</p>
+          </div>
+          <div className={styles.serviceCard}>
+            <h4>Commerces en ligne</h4>
+            <p>Boutiques WooCommerce, intégration Stripe et flux de paiement personnalisés.</p>
+          </div>
+          <div className={styles.serviceCard}>
+            <h4>Logiciels bureautiques</h4>
+            <p>Applications multiplateformes pour Windows et Mac, construites avec Electron.js.</p>
+          </div>
+          <div className={styles.serviceCard}>
+            <h4>Web scraping</h4>
+            <p>Extraction de données, automatisation et intégration d'API pour des flux de travail automatisés.</p>
+          </div>
+          <div className={styles.serviceCard}>
+            <h4>Scripts d'automatisation</h4>
+            <p>Automatisation de tâches Windows, traitement de fichiers et outils pour gagner du temps.</p>
+          </div>
+          <div className={styles.serviceCard}>
+            <h4>Consultation et maintenance</h4>
+            <p>Revue de code, optimisation des performances et soutien à long terme.</p>
+          </div>
+        </div>
       </section>
 
       <svg className={styles.waveBottom} xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 150">

--- a/styles/contact.module.css
+++ b/styles/contact.module.css
@@ -29,3 +29,83 @@
   left: 16%;
   transform: rotateZ(2deg);
 }
+
+/* --- Contact Form --- */
+.contactForm {
+  margin: 2rem 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.formField {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.formField label {
+  font-weight: 500;
+  font-size: 0.95rem;
+}
+
+.formField input,
+.formField textarea {
+  padding: 0.7rem 0.85rem;
+  border: 1px solid var(--main-border-color);
+  border-radius: 6px;
+  background-color: var(--main-background-color);
+  color: var(--main-foreground-color);
+  font-family: inherit;
+  font-size: 1rem;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.formField input:focus,
+.formField textarea:focus {
+  outline: none;
+  border-color: var(--blue);
+  box-shadow: 0 0 0 2px rgba(0, 102, 255, 0.15);
+}
+
+.formField input::placeholder,
+.formField textarea::placeholder {
+  color: var(--secondary-text-color);
+  opacity: 0.65;
+}
+
+.submitButton {
+  align-self: flex-start;
+  padding: 0.75rem 1.75rem;
+  background-color: var(--blue);
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-family: inherit;
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: filter 0.2s;
+}
+
+.submitButton:hover {
+  filter: brightness(1.1);
+}
+
+.submitButton:focus-visible {
+  outline: 2px solid var(--blue);
+  outline-offset: 2px;
+}
+
+.formNote {
+  font-size: 0.85rem;
+  color: var(--secondary-text-color);
+  margin: 0.5rem 0 0 0;
+}
+
+.formSuccess {
+  padding: 1.5rem;
+  border: 1px solid var(--blue);
+  border-radius: 8px;
+  background-color: rgba(0, 102, 255, 0.08);
+}

--- a/styles/programmation.module.css
+++ b/styles/programmation.module.css
@@ -41,18 +41,57 @@
   font-size: 2.5rem;
 }
 
-.services ul {
-  list-style: none;
-  padding: 0;
+.servicesGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
   width: 100%;
-  margin: 3rem 0 1.5rem 0;
+  max-width: 1000px;
+  margin: 2rem auto 0;
+  padding: 0 1.5rem 2.5rem;
 }
 
-.services li {
-  color: inherit;
-  font-size: 1.25rem;
+.serviceCard {
+  background-color: rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  padding: 1.5rem;
   text-align: center;
-  line-height: 2.25;
+  transition: transform 0.2s, background-color 0.2s;
+}
+
+.serviceCard:hover {
+  transform: translateY(-4px);
+  background-color: rgba(255, 255, 255, 0.2);
+}
+
+.serviceCard h4 {
+  margin: 0 0 0.5rem 0;
+  font-size: 1.15rem;
+  font-family: var(--ff-sans-serif);
+}
+
+.serviceCard p {
+  margin: 0;
+  font-size: 0.925rem;
+  opacity: 0.9;
+}
+
+@supports (backdrop-filter: blur(6px)) {
+  .serviceCard {
+    backdrop-filter: blur(6px);
+    -webkit-backdrop-filter: blur(6px);
+  }
+}
+
+@media screen and (max-width: 1024px) {
+  .servicesGrid {
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+    padding: 0 1rem 2rem;
+  }
+  .serviceCard {
+    padding: 1.25rem;
+  }
 }
 
 .projects {


### PR DESCRIPTION
- Add ContactForm component (client-side mailto: generator) with EN/FR labels
- Integrate contact form into EN and FR contact pages
- Style contact form with theme-aware inputs, focus states, and success state
- Replace Offered Services plain list with grid of service cards with descriptions
- Fix dual H1 headings: nav logo now uses span instead of h1
- Fix generic aria-labels: ExternalLink now accepts ariaLabel prop for context
- Add descriptive aria-labels to footer social links and project links