### PR TITLE
a11y: guard button lift and image crossfade with prefers-reduced-motion

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -213,10 +213,6 @@ p + p {
   margin-top: 1.1rem;
 }
 
-:is(p, span):hover {
-  color: var(--main-foreground-color);
-}
-
 .text-link {
   text-decoration: underline;
   color: var(--main-text-link-color);

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -688,6 +688,16 @@ html.dark .btn-secondary:hover {
   .hero-skill-chip {
     animation: none;
   }
+
+  /* Button lift and image opacity crossfade are non-essential motion */
+  .btn,
+  .stylish-shadow-image img {
+    transition: none;
+  }
+
+  .btn:hover {
+    transform: none;
+  }
 }
 
 @media screen and (max-width: 1250px) {

--- a/styles/programmation.module.css
+++ b/styles/programmation.module.css
@@ -109,10 +109,6 @@
   line-height: 1.55;
 }
 
-.serviceDescription:hover {
-  color: var(--service-card-description);
-}
-
 .serviceCard:hover {
   color: #fff;
   border-color: var(--service-card-border-hover);


### PR DESCRIPTION
The .btn hover transform (translateY) and .stylish-shadow-image img opacity crossfade were the only unguarded motion left on the site — orbits, skill chips, sheen animations, and the page fade-in already respected prefers-reduced-motion. Extend the existing reduce block to disable these transitions so users with reduced-motion preference get instant state changes instead of a transform/opacity animation.